### PR TITLE
remove broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 ![Banner](Baldoyle-Training-720x480.jpg)
 
 # Table of Contents
@@ -9,96 +7,58 @@
 - Watch Courses Online
 - Download Courses
 
-
-
-
 ## Website For Free Downloads
+
 > Download Paid Udemy Courses for Free
 
-| Website  | Description |
-| ------ | ------ |
-| [freecoursesonline](https://www.freecoursesonline.me/) | Free Courses Online Free Download Torrent of Phlearn, Pluralsight, Lynda, CBTNuggets, Laracasts, Coursera, Linkedin, Teamtreehouse etc. |
-| [getfreecourses](https://getfreecourses.co/) | Download Udemy Paid Courses for Free. Learn Hacking, Programming, IT & Software, Marketing, Music, Free Online Courses, and more. Active site to upload udemy courses |
-| [tutorialsplanet](https://tutorialsplanet.net/) | Download Udemy Paid Courses for Free. Learn Hacking, Programming, IT & Software, Marketing, Music, Free Online Courses, and more. Active site to upload udemy courses |
-| [desirecourse](https://desirecourse.net/) | Download Udemy Paid Courses for Free. Learn Hacking, Programming, IT & Software, Marketing, Music, Free Online Courses, and more. |
-| [freecoursesite](https://freecoursesite.com/) | Download Udemy Paid Courses for Free. Learn Hacking, Programming, IT & Software, Marketing, Music, Free Online Courses, and more. Not active |
-| [courseclub](https://courseclub.me/) | Download Free Courses Online of Phlearn, Pluralsight, Lynda, CBTNuggets etc. Everything is Full And Free For Download And Many More. |
-| [freecourselab](https://freecourselab.me/) | Download Paid Udemy Courses for Free. Learn Hacking, Development, Programming, IT & Software, Marketing, Music, Free Online Courses, and more. |
-| [online-courses](https://online-courses.club/) | Watch and Learn. Educate yourself! |
-| [pimpmymoney](https://pimpmymoney.net/) | Turbocharge your money instantly. FREE access to the latest Digital Marketing Courses. |
-| [freetutsdownload](https://freetutsdownload.com/) | Download All Course Free |
-| [udemyfreecourses](https://udemyfreecourses.org/) | find ALL free courses of Udemy in an easy and quick way. |
-| [free-programming-books](https://ebookfoundation.github.io/free-programming-books/) | Freely available programming books, online courses and Podcast. |
-| [courseghar.com](https://coursesghar.com/tutorialsv1/) | Download Paid Udemy Courses for Free. Learn Hacking, Development, Programming and IT & Software
-| [tutsnode](https://tutsnode.net/) | Best website for downloading paid Udemy Courses for free. |
-
-
+| Website                                                                             | Description                                                                                                                                  |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [freecoursesite](https://freecoursesite.com/)                                       | Download Udemy Paid Courses for Free. Learn Hacking, Programming, IT & Software, Marketing, Music, Free Online Courses, and more. Not active |
+| [online-courses](https://online-courses.club/)                                      | Watch and Learn. Educate yourself!                                                                                                           |
+| [pimpmymoney](https://pimpmymoney.net/)                                             | Turbocharge your money instantly. FREE access to the latest Digital Marketing Courses.                                                       |
+| [udemyfreecourses](https://udemyfreecourses.org/)                                   | find ALL free courses of Udemy in an easy and quick way.                                                                                     |
+| [free-programming-books](https://ebookfoundation.github.io/free-programming-books/) | Freely available programming books, online courses and Podcast.                                                                              |
 
 ## Free and Discount Coupons
-> Get Free and Discount Coupons 
 
-| Website  | Description |
-| ------ | ------ |
-| [Coursesity](https://coursesity.com/) | Find free courses from udemy and other e-providers at one place. |
-| [discudemy](https://www.discudemy.com/) | Find best Udemy Promo Codes and Deals on this page and get the best saving on your online learning. |
-| [100offdeal](https://100offdeal.online/) | Udemy Free Courses 2020 (Updated Daily) -Get Latest 100 OFF Udemy Free Coupons & Udemy Premium Courses for Free. |
-| [real.discount](https://www.real.discount/) | Free online courses, udemy free courses, coursera free courses, open university free courses, free online courses with certificates |
-| [udemycoupons](https://udemycoupons.me/) | Best Udemy Courses with up to 100% OFF Udemy Coupons Codes For Today. |
-| [myhelpcovid19](https://myhelpcovid19.info/freecourses/) | group of dedicated volunteers who like to help people by aggregating data from different sources and put it in myhelpcovid19 website. |
-| [comidoc](https://comidoc.net/) | Online Courses Tracker |
-| [smartybro](https://smartybro.com/) | Top Free Online Courses Including Coursera/Eduonix/Skillshare and Udemy Courses for Limited Time Only, . Enroll using Free Coupon Today, |
-| [jojocoupons](https://jojocoupons.com/) | Top Free Udemy Coupon Courses of Udemy Coursera, Eduonix, Skillshare much more Enroll For Limited Time Enjoy |
-| [udemycoupon.learnviral](https://udemycoupon.learnviral.com/) | Free and $10 Udemy coupons added daily. Visit now and get your coupons before they expire! |
-| [coupdemy](https://coupdemy.com/) | Get latest Udemy coupons up to 100% OFF discount and absolutely free. Daily updates also available for Namecheap, Coursera and other heigh demand products. |
-| [tutsnode](https://tutsnode.net/) | Free Courses |
-| [nocourses](https://nocourses.com/) | A place for sharing knowledge with each other |
-| [freecoursesforall](https://freecoursesforall.com/) | Get Latest Coupons | 
-| [couponscorpion](https://couponscorpion.com/) | 100% Off Udemy coupon codes and free Udemy courses added daily. Save with working Udemy coupon codes, offers, and discounts. |
-| [couponstown](https://couponstown.me/) | CouponsTown Provide Udemy Coupon, Free Online Courses, Certificates, Free e-courses, Udemy Free Courses, 100% Working Free Tutorials |
-| [inventhigh](https://inventhigh.com/course) | Get Free and Offer Courses - Upgrade Yourself |
-| [jucktion udemy coupons](https://www.jucktion.com/forum/udemy-coupon/) | Free Udemy Coupon Code for Premium Courses - Updated and Checked Daily |
-| [techlinks](https://techlinks.in/udemy-free-coupons) | 100% Off Udemy coupon codes and free Udemy courses added daily |
-| [Freewebcart](https://www.freewebcart.com/) | Get certified with Udemy Free Courses with Certificate. Boost your skills, learn from experts, and start your success journey today. |
-| [Course Joiner](https://www.coursejoiner.com/tag/100-off/) | 100% Off Udemy Premium Courses coupon, jobs & internship opportunities. |
-| [Korshub](https://www.korshub.com/courses/platform/udemy-coupons) | Udemy, SkillShare, Kajabi, Coursera and many more platform courses 100% off free and discount coupons.  |
-| [Scroll Coupons](https://scrollcoupons.com/) | Get the freshest Udemy coupons and access to the best courses, keep up to date and enjoy 100% off coupon codes.  |
-| [coursevania](https://coursevania.com/) | Unlock your potential with our free online courses! Explore a world of skill-building opportunities without any cost!  |
-| [UdemyXpert](https://udemyxpert.com/) | Get 100% free Udemy coupons and discounts. Find the latest and most popular Udemy coupon codes for free and level up your skills today. |
+> Get Free and Discount Coupons
+
+| Website                                                                | Description                                                                                                                             |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| [Coursesity](https://coursesity.com/)                                  | Find free courses from udemy and other e-providers at one place.                                                                        |
+| [discudemy](https://www.discudemy.com/)                                | Find best Udemy Promo Codes and Deals on this page and get the best saving on your online learning.                                     |
+| [100offdeal](https://100offdeal.online/)                               | Udemy Free Courses 2020 (Updated Daily) -Get Latest 100 OFF Udemy Free Coupons & Udemy Premium Courses for Free.                        |
+| [real.discount](https://www.real.discount/)                            | Free online courses, udemy free courses, coursera free courses, open university free courses, free online courses with certificates     |
+| [comidoc](https://comidoc.net/)                                        | Online Courses Tracker                                                                                                                  |
+| [couponscorpion](https://couponscorpion.com/)                          | 100% Off Udemy coupon codes and free Udemy courses added daily. Save with working Udemy coupon codes, offers, and discounts.            |
+| [inventhigh](https://inventhigh.com/course)                            | Get Free and Offer Courses - Upgrade Yourself                                                                                           |
+| [jucktion udemy coupons](https://www.jucktion.com/forum/udemy-coupon/) | Free Udemy Coupon Code for Premium Courses - Updated and Checked Daily                                                                  |
+| [Freewebcart](https://www.freewebcart.com/)                            | Get certified with Udemy Free Courses with Certificate. Boost your skills, learn from experts, and start your success journey today.    |
+| [Course Joiner](https://www.coursejoiner.com/tag/100-off/)             | 100% Off Udemy Premium Courses coupon, jobs & internship opportunities.                                                                 |
+| [Korshub](https://www.korshub.com/courses/platform/udemy-coupons)      | Udemy, SkillShare, Kajabi, Coursera and many more platform courses 100% off free and discount coupons.                                  |
+| [Scroll Coupons](https://scrollcoupons.com/)                           | Get the freshest Udemy coupons and access to the best courses, keep up to date and enjoy 100% off coupon codes.                         |
+| [coursevania](https://coursevania.com/)                                | Unlock your potential with our free online courses! Explore a world of skill-building opportunities without any cost!                   |
+| [UdemyXpert](https://udemyxpert.com/)                                  | Get 100% free Udemy coupons and discounts. Find the latest and most popular Udemy coupon codes for free and level up your skills today. |
+| [Foundthejob](https://foundthejob.com/?s=course)                       | Free Courses for all                                                                                                                    |
 
 ## Watch Courses Online
-> watch live courses 
 
-| Website  | Description |
-| ------ | ------ |
-| [ustreamy](https://www.ustreamy.co) | Stream and Watch free udemy courses online. Thousands of paid udemy courses from top udemy instructors are available. Download udemy tutorials for free. |
-| [learningcrux](https://www.learningcrux.com/) | Free Tutorials & udemy free download. Python, JavaScript, Machine Learning, SEO, Hacking, Photography tutorials Download and Watch Udemy Paid Courses for Free. |
-| [umecourses](https://umecourses.xyz/) | Watch and Download Udemy Paid Courses for Free. Learn Hacking, Programming, IT & Software, Marketing, Music, Free Online Courses, Machine learning and more. |
+> watch live courses
+
+| Website                                | Description                                           |
+| -------------------------------------- | ----------------------------------------------------- |
 | [sololearn](https://www.sololearn.com) | Courses designed by experts with real-world practice. |
 
-
 ## Download Courses
+
 > Download Courses to your pc or remote cloud
 
-| Repository	  | Description |
-| ------ | ------ |
-| [udemy-dl](https://github.com/r0oth3x49/udemy-dl) | A cross-platform python based utility to download courses from udemy for personal offline use.  |
-| [udemy-dl-node](https://github.com/riazXrazor/udemy-dl) | Nodejs script to download a udemy.com course, for personal offline use  |
-| [udemy-dl-windows](https://github.com/rinodung/udemy-dl-windows) | A windows utility to download videos from udemy for personal offline use  |
-| [skillshare-downloader](https://github.com/kallqvist/skillshare-downloader) | Skillshare video downloader in python |
-| [udacimak](https://github.com/udacimak/udacimak) | Udacity Nanodegree Downloader |
-| [Foundthejob](https://foundthejob.com/?s=course) |Free Courses for all |
+| Repository                                                                  | Description                                                                                    |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [udemy-dl](https://github.com/r0oth3x49/udemy-dl)                           | A cross-platform python based utility to download courses from udemy for personal offline use. |
+| [udemy-dl-node](https://github.com/riazXrazor/udemy-dl)                     | Nodejs script to download a udemy.com course, for personal offline use                         |
+| [udemy-dl-windows](https://github.com/rinodung/udemy-dl-windows)            | A windows utility to download videos from udemy for personal offline use                       |
+| [skillshare-downloader](https://github.com/kallqvist/skillshare-downloader) | Skillshare video downloader in python                                                          |
+| [udacimak](https://github.com/udacimak/udacimak)                            | Udacity Nanodegree Downloader                                                                  |
 
 ### Pull requests are welcome.
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Changes Made:
1. Removed the following websites from the "Website For Free Downloads" section:
   - [freecoursesonline](https://www.freecoursesonline.me/)
   - [getfreecourses](https://getfreecourses.co/)
   - [tutorialsplanet](https://tutorialsplanet.net/)
   - [desirecourse](https://desirecourse.net/)
   - [courseclub](https://courseclub.me/)
   - [freecourselab](https://freecourselab.me/)
   - [freetutsdownload](https://freetutsdownload.com/)
   - [courseghar.com](https://coursesghar.com/tutorialsv1/)
   - [tutsnode](https://tutsnode.net/)

2. Removed the following websites from the "Free and Discount Coupons" section:
   - [udemycoupons](https://udemycoupons.me/)
   - [myhelpcovid19](https://myhelpcovid19.info/freecourses/)
   - [smartybro](https://smartybro.com/)
   - [jojocoupons](https://jojocoupons.com/)
   - [udemycoupon.learnviral](https://udemycoupon.learnviral.com/)
   - [coupdemy](https://coupdemy.com/)
   - [tutsnode](https://tutsnode.net/)
   - [nocourses](https://nocourses.com/)
   - [freecoursesforall](https://freecoursesforall.com/)
   - [couponstown](https://couponstown.me/)
   - [techlinks](https://techlinks.in/udemy-free-coupons)

3. Removed the following websites from the "Watch Courses Online" section:
   - [ustreamy](https://www.ustreamy.co)
   - [learningcrux](https://www.learningcrux.com/)
   - [umecourses](https://umecourses.xyz/)

4. Moved the following website from the "Download Courses" section to the "Free and Discount Coupons" section:
   - [Foundthejob](https://foundthejob.com/?s=course)